### PR TITLE
Remove empty state from products component

### DIFF
--- a/src/components/Products/Products.tsx
+++ b/src/components/Products/Products.tsx
@@ -1,12 +1,9 @@
-import { SimpleGrid, Text } from '@mantine/core';
-import _ from 'lodash';
+import { SimpleGrid } from '@mantine/core';
 import { Product } from './Product';
 import { Product as ProductType } from '@/types';
 
 export function Products({ products }: { products: ProductType[] }) {
-  return _.isEmpty(products) ? (
-    <Text>No products :\</Text>
-  ) : (
+  return (
     <SimpleGrid
       cols={{ base: 1, sm: 2, lg: 3 }}
       spacing={{ base: 10, sm: 'xl' }}


### PR DESCRIPTION
## Describe your changes
- the main home screen has logic to not render the Products component if there is no data. This removes the legacy empty state from the Products component.

## Screenshot
N/A
